### PR TITLE
add sum type sample programs

### DIFF
--- a/other_sample_programs/more_sum_types/Cargo.toml
+++ b/other_sample_programs/more_sum_types/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "more_sum_types"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/other_sample_programs/more_sum_types/src/main.rs
+++ b/other_sample_programs/more_sum_types/src/main.rs
@@ -1,0 +1,46 @@
+
+
+
+fn main() {
+    let mut canary : i64 = 0;
+    let v1 : Option<i64> = None;
+
+    match v1 {
+        None => canary = 0,
+        Some(_) => canary = 1,
+    }
+    
+    let v2 : Option<i64> = Some(31);
+    match v2 {
+        None => canary = 0,
+        Some(_) => canary = 1,
+    }
+
+
+    let v3 : Option<String> = None;
+    match v3 {
+        None => canary = 0,
+        Some(_) => canary = 1,
+    }
+
+    let v4 : Option<String> = Some(String::from("thirty-two"));
+    match v4 {
+        None => canary = 0,
+        Some(_) => canary = 1,
+    }
+
+    let v5 : Option<Vec<i64>> = None;
+    match v5 {
+        None => canary = 0,
+        Some(_) => canary = 1,
+    }
+
+    let v6 : Option<Vec<i64>> = Some(vec![33,34,35,6]);
+    match v6 {
+        None => canary = 0,
+        Some(_) => canary = 1,
+    }
+
+}
+    
+    

--- a/other_sample_programs/sum_types/Cargo.toml
+++ b/other_sample_programs/sum_types/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "sum_types"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/other_sample_programs/sum_types/src/main.rs
+++ b/other_sample_programs/sum_types/src/main.rs
@@ -1,0 +1,82 @@
+#[derive(Debug)]
+struct HappyStruct {
+    a: String,
+    b: i64,
+    c: String
+}
+
+#[derive(Debug)]
+struct SadStruct {
+    a: i64,
+    b: i64
+}
+
+enum SumType0 {
+    JustOneOption(i64)
+}
+
+enum SumType1 {
+    OneOption(i64),
+    AnotherOption(i64)
+}
+
+enum SumType2 {
+    OneOption(i64),
+    AnotherOption(String)
+}
+
+enum SumType3 {
+    JustANumber(i64),
+    Happy(HappyStruct)
+}
+
+enum SumType4 {
+    Happy(HappyStruct),
+    Sad(SadStruct),
+    JustANumber(i64)
+}
+
+
+
+fn main() {
+    let sumtype_0_0 = SumType0::JustOneOption(10);
+    let sumtype_1_0 = SumType1::OneOption(11);
+    let sumtype_1_1 = SumType1::AnotherOption(12);
+    let sumtype_2_0 = SumType2::OneOption(13);
+    let sumtype_2_1 = SumType2::AnotherOption(String::from("Fourteen"));
+    let sumtype_3_0 = SumType3::JustANumber(14);
+    let sumtype_3_1 = SumType3::Happy(HappyStruct {a: String::from("Fifteen"), b: 16, c: String::from("Seventeen")});
+    let sumtype_4_0 = SumType4::Happy(HappyStruct {a: String::from("Eighteen"), b: 19, c: String::from("Twenty")});
+    let sumtype_4_1 = SumType4::Sad(SadStruct {a: 21, b: 22});
+    let sumtype_4_2 = SumType4::JustANumber(23);
+
+    match sumtype_0_0 {
+        SumType0::JustOneOption(x) => println!("0_0: JustOneOption, {}", x),
+    }
+    match sumtype_1_0 {
+        SumType1::OneOption(x) => println!("1_0: OneOption, {}", x),
+        SumType1::AnotherOption(x) => println!("1_0: AnotherOption, {}", x),
+    }
+    match sumtype_1_1 {
+        SumType1::OneOption(x) => println!("1_1: OneOption, {}", x),
+        SumType1::AnotherOption(x) => println!("1_1: AnotherOption, {}", x),
+    }
+    match sumtype_2_0 {
+        SumType2::OneOption(x) => println!("2_0: OneOption, {}", x),
+        SumType2::AnotherOption(x) => println!("2_0: AnotherOption, {}", x),
+    }
+    match sumtype_2_1 {
+        SumType2::OneOption(x) => println!("2_1: OneOption, {}", x),
+        SumType2::AnotherOption(x) => println!("2_1: AnotherOption, {}", x),
+    }
+    match sumtype_3_0 {
+        SumType3::JustANumber(x) => println!("3_0: JustANumber, {}", x),
+        SumType3::Happy(x) => println!("3_0: Happy, {:?}", x),
+    }
+    match sumtype_3_1 {
+        SumType3::JustANumber(x) => println!("3_1: JustANumber, {}", x),
+        SumType3::Happy(x) => println!("3_1: Happy, {:?}", x),
+    }
+}
+    
+    

--- a/other_sample_programs/truly_pathological_sum_types/Cargo.toml
+++ b/other_sample_programs/truly_pathological_sum_types/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "truly_pathological_sum_types"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/other_sample_programs/truly_pathological_sum_types/src/main.rs
+++ b/other_sample_programs/truly_pathological_sum_types/src/main.rs
@@ -1,0 +1,44 @@
+enum Degenerate {
+    Member()
+}
+
+enum AlsoDegenerate {
+    Member0(),
+    Member1(),
+    Member2(),
+}
+
+
+
+fn main() {
+    let mut canary : i64 = 0;
+    
+    let v1 : Option<&str> = Some("eighty-seven");
+    match v1 {
+        None => canary = 0,
+        Some(_) => canary = 1,
+    }
+    
+    let v2 : Option<&str> = None;
+    match v2 {
+        None => canary = 0,
+        Some(_) => canary = 1,
+    }
+
+
+    let v3 : Degenerate = Degenerate::Member();
+    match v3 {
+        Degenerate::Member() => canary = 0,
+        _ => unreachable!()
+    }
+
+    let v4 : AlsoDegenerate = AlsoDegenerate::Member2();
+
+    match v4 {
+        AlsoDegenerate::Member0() => canary = 40,
+        AlsoDegenerate::Member1() => canary = 41,
+        AlsoDegenerate::Member2() => canary = 42,
+    }
+
+}
+


### PR DESCRIPTION
Add programs that, when compiled, illustrate how rustc handles sum types when converting to assembly.